### PR TITLE
Update view.css

### DIFF
--- a/resources/view.css
+++ b/resources/view.css
@@ -34,7 +34,6 @@ table thead tr,
 table tfoot tr {
     line-height: 2.5;
     background-color: var(--vscode-editorGroupHeader-tabsBackground);
-    color: var(--vscode-tab-activeForeground);
 }
 
 table thead tr th {
@@ -52,15 +51,12 @@ table thead tr th {
  */
 table thead tr th::after {
     content: '\20\25b2';
-    color: var(--vscode-editorGroupHeader-tabsBackground);
 }
 table thead tr th[data-asc=true]::after {
     content: '\20\25b2';
-    color: var(--vscode-tab-activeForeground);
 }
 table thead tr th[data-asc=false]::after {
     content: '\20\25bc';
-    color: var(--vscode-tab-activeForeground);
 }
 
 table tbody tr:nth-child(even) {


### PR DESCRIPTION
在 Visual Studio 2017 Light Theme 主题环境下，使用该插件发现结果表格的标题栏和底部统计的文字很难看清，文字颜色太接近。
https://marketplace.visualstudio.com/items?itemName=vfd.vs2017-light-theme

该提交移除表格头部与尾部的颜色，以适应vscode的其它主题（已测试默认主题的显示效果）